### PR TITLE
Add Post model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,14 @@
 AllCops:
   Exclude:
     - 'spec/**/*'
-    - 'db/**'
-    - 'bin/**'
+    - 'test/**/*'
+    - 'db/**/*'
+    - 'bin/**/*'
     - 'app/javascript/**'
-    - 'config/**'
+    - 'node_modules/**/*'
+    - 'config/**/*'
+    - 'lib/tasks/**/*'
+    - 'lib/assets/**/*'
 
   TargetRubyVersion: 2.6
 
@@ -12,4 +16,7 @@ Metrics/LineLength:
   Max: 120
 
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'annotate'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'overcommit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,9 @@ GEM
       zeitwerk (~> 2.1, >= 2.1.8)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (2.6.5)
+      activerecord (>= 2.3.0)
+      rake (>= 0.8.7)
     ast (2.4.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -254,6 +257,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,7 +5,7 @@
 #  id         :integer          not null, primary key
 #  author     :string           not null
 #  body       :text
-#  likes      :integer          default("0")
+#  likes      :integer
 #  location   :point
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id         :integer          not null, primary key
+#  author     :string           not null
+#  body       :text
+#  likes      :integer          default("0")
+#  location   :point
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_posts_on_author  (author)
+#
+
+class Post < ApplicationRecord
+end

--- a/db/migrate/20191023062528_create_posts.rb
+++ b/db/migrate/20191023062528_create_posts.rb
@@ -1,0 +1,14 @@
+class CreatePosts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :posts do |t|
+      t.string :author, null: false
+      t.text :body
+      t.integer :likes, default: 0
+      t.point :location
+
+      t.timestamps
+    end
+
+    add_index :posts, :author
+  end
+end

--- a/db/migrate/20191023062528_create_posts.rb
+++ b/db/migrate/20191023062528_create_posts.rb
@@ -3,7 +3,7 @@ class CreatePosts < ActiveRecord::Migration[6.0]
     create_table :posts do |t|
       t.string :author, null: false
       t.text :body
-      t.integer :likes, default: 0
+      t.integer :likes
       t.point :location
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2019_10_23_062528) do
   create_table "posts", force: :cascade do |t|
     t.string "author", null: false
     t.text "body"
-    t.integer "likes", default: 0
+    t.integer "likes"
     t.point "location"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2019_10_23_062528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.string "author", null: false
+    t.text "body"
+    t.integer "likes", default: 0
+    t.point "location"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["author"], name: "index_posts_on_author"
+  end
 
 end

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,34 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults({
+      'position_in_routes'   => "before",
+      'position_in_class'    => "before",
+      'position_in_test'     => "before",
+      'position_in_fixture'  => "before",
+      'position_in_factory'  => "before",
+      'show_indexes'         => "true",
+      'simple_indexes'       => "false",
+      'model_dir'            => "app/models",
+      'include_version'      => "false",
+      'require'              => "",
+      'exclude_tests'        => "false",
+      'exclude_fixtures'     => "false",
+      'exclude_factories'    => "false",
+      'ignore_model_sub_dir' => "false",
+      'skip_on_db_migrate'   => "false",
+      'format_bare'          => "true",
+      'format_rdoc'          => "false",
+      'format_markdown'      => "false",
+      'sort'                 => "false",
+      'force'                => "false",
+      'trace'                => "false",
+    })
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -5,7 +5,7 @@
 #  id         :integer          not null, primary key
 #  author     :string           not null
 #  body       :text
-#  likes      :integer          default("0")
+#  likes      :integer
 #  location   :point
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id         :integer          not null, primary key
+#  author     :string           not null
+#  body       :text
+#  likes      :integer          default("0")
+#  location   :point
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_posts_on_author  (author)
+#
+
+FactoryBot.define do
+  factory :post do
+    sequence(:author) { |n| "user#{n}" }
+    body { 'fakebody' }
+    likes { 0 }
+    location { ActiveRecord::Point.new(0, 0) }
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id         :integer          not null, primary key
+#  author     :string           not null
+#  body       :text
+#  likes      :integer          default("0")
+#  location   :point
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_posts_on_author  (author)
+#
+
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -5,7 +5,7 @@
 #  id         :integer          not null, primary key
 #  author     :string           not null
 #  body       :text
-#  likes      :integer          default("0")
+#  likes      :integer
 #  location   :point
 #  created_at :datetime         not null
 #  updated_at :datetime         not null


### PR DESCRIPTION
## Changes
- Adds Post model (empty for now, this PR can just be to check schema + correct model creation)
    - The commands used:
    - `rails g model Post author:string body:text etcetcetc`
    - `rake db:migrate`
- Adds schema annotations to model/controller/spec files
- Rubocop :(

#### Attached issue?
#14 