### PR TITLE
Add location to posts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ Style/FrozenStringLiteralComment:
 
 Style/Documentation:
   Enabled: false
+
+Style/SymbolArray:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'devise'
+gem 'geokit-rails'
+
 gem 'react-rails'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,10 @@ GEM
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
     ffi (1.11.1)
+    geokit (1.13.1)
+    geokit-rails (2.3.1)
+      geokit (~> 1.5)
+      rails (>= 3.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.7.0)
@@ -286,6 +290,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   devise
   factory_bot_rails
+  geokit-rails
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   overcommit

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,7 +22,6 @@ class PostsController < ApplicationController
     @post.likes = 0
     @post.user_id = current_user.id
     @post.latitude, @post.longitude = @location
-    puts @location.inspect
     @post.save!
 
     redirect_to @post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
       5, # TODO: param
       units: :miles,
       origin: @location
-    ).by_distance(:origin => @location)
+    ).by_distance(origin: @location)
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
       5, # TODO: param
       units: :miles,
       origin: @location
-    )
+    ).by_distance(:origin => @location)
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,8 +1,15 @@
 class PostsController < ApplicationController
   # before_action :check_logged_in, only: [:create]
+  geocode_ip_address
+  before_action :get_location, only: [:index, :new, :create]
 
   def index
-    @posts = Post.all
+    # @posts = Post.all
+    @posts = Post.within(
+      5, # TODO: param
+      :units => :miles,
+      :origin => @location
+    )
   end
 
   def show
@@ -11,9 +18,11 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.new(post_params) # TODO: author, location
+    @post = Post.new(post_params) # TODO: author?
     @post.likes = 0
     @post.user_id = current_user.id
+    @post.latitude, @post.longitude = @location
+    puts @location.inspect
     @post.save!
 
     redirect_to @post
@@ -29,6 +38,11 @@ class PostsController < ApplicationController
 
   def post_params
     params.require(:post).permit(:title, :body)
+  end
+
+  def get_location
+    @location = session[:geo_location].slice("lat", "lng").values
+    @location ||= [0, 0] # TODO: something better
   end
 
   def check_logged_in

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,14 +1,14 @@
 class PostsController < ApplicationController
   # before_action :check_logged_in, only: [:create]
   geocode_ip_address
-  before_action :get_location, only: [:index, :new, :create]
+  before_action :location, only: [:index, :new, :create]
 
   def index
     # @posts = Post.all
     @posts = Post.within(
       5, # TODO: param
-      :units => :miles,
-      :origin => @location
+      units: :miles,
+      origin: @location
     )
   end
 
@@ -40,8 +40,8 @@ class PostsController < ApplicationController
     params.require(:post).permit(:title, :body)
   end
 
-  def get_location
-    @location = session[:geo_location].slice("lat", "lng").values
+  def location
+    @location = session[:geo_location].slice('lat', 'lng').values
     @location ||= [0, 0] # TODO: something better
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,14 +5,25 @@
 #  id         :integer          not null, primary key
 #  body       :text
 #  likes      :integer
-#  location   :point
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  title      :string
 #  user_id    :integer
+#  latitude   :decimal(10, 6)
+#  longitude  :decimal(10, 6)
+#
+# Indexes
+#
+#  index_posts_on_latitude_and_longitude  (latitude,longitude)
 #
 
 class Post < ApplicationRecord
+  acts_as_mappable default_units: :miles,
+                   default_formula: :sphere,
+                   distance_field_name: :distance,
+                   lat_column_name: :latitude,
+                   lng_column_name: :longitude
+
   belongs_to :user
   has_many :comments
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,10 +1,13 @@
 <%= render 'shared/header' %>
 <%= link_to 'New post', '/posts/new' %>
 
+<p>Your location: <%= @location.first %>, <%= @location.last %></p>
+
 <% @posts.each do |post| %>
   <div>
     <h1><%= post.title %></h1>
     <h3>spice level: <%= post.likes %></h3>
+    <h3><%= post.latitude %>, <%= post.longitude %></h3>
     <p><%= link_to 'Full post', post_path(post) %></p>
-  </div> 
+  </div>
 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -13,6 +13,8 @@
       <%= form.text_area :body %>
     </p>
 
+    <p>Location: <%= @location.first %>, <%= @location.last %></p>
+
     <p>
       <%= form.submit %>
     </p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,6 +2,7 @@
 
 <h1><%= @post.title %></h1>
 <h4>spice level: <%= @post.likes %></h4>
+<h4><%= @post.latitude %>, <%= @post.longitude %></h4>
 <p><%= @post.body %></p>
 
 <% if user_signed_in? %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,10 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  class ActionDispatch::Request
+    def remote_ip
+      "23.243.51.30"
+    end
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
 
   class ActionDispatch::Request
     def remote_ip
-      "23.243.51.30"
+      '23.243.51.30'
     end
   end
 end

--- a/config/initializers/geokit_config.rb
+++ b/config/initializers/geokit_config.rb
@@ -1,0 +1,100 @@
+# These defaults are used in Geokit::Mappable.distance_to and acts_as_mappable
+Geokit::default_units = :miles # others :kms, :nms, :meters
+Geokit::default_formula = :sphere
+
+# This is the timeout value in seconds to be used for calls to the geocoder web
+# services.  For no timeout at all, comment out the setting.  The timeout unit
+# is in seconds.
+Geokit::Geocoders::request_timeout = 3
+
+# This setting can be used if web service calls must be routed through a proxy.
+# These setting can be nil if not needed, otherwise, a valid URI must be
+# filled in at a minimum.  If the proxy requires authentication, the username
+# and password can be provided as well.
+# Geokit::Geocoders::proxy = 'https://user:password@host:port'
+
+# This is your yahoo application key for the Yahoo Geocoder.
+# See http://developer.yahoo.com/faq/index.html#appid
+# and http://developer.yahoo.com/maps/rest/V1/geocode.html
+# Geokit::Geocoders::YahooGeocoder.key = 'REPLACE_WITH_YOUR_YAHOO_KEY'
+# Geokit::Geocoders::YahooGeocoder.secret = 'REPLACE_WITH_YOUR_YAHOO_SECRET'
+
+# This is your Google Maps geocoder keys (all optional).
+# See http://www.google.com/apis/maps/signup.html
+# and http://www.google.com/apis/maps/documentation/#Geocoding_Examples
+# Geokit::Geocoders::GoogleGeocoder.client_id = ''
+# Geokit::Geocoders::GoogleGeocoder.cryptographic_key = ''
+# Geokit::Geocoders::GoogleGeocoder.channel = ''
+
+# You can also use the free API key instead of signed requests
+# See https://developers.google.com/maps/documentation/geocoding/#api_key
+# Geokit::Geocoders::GoogleGeocoder.api_key = ''
+
+# You can also set multiple API KEYS for different domains that may be directed
+# to this same application.
+# The domain from which the current user is being directed will automatically
+# be updated for Geokit via
+# the GeocoderControl class, which gets it's begin filter mixed
+# into the ActionController.
+# You define these keys with a Hash as follows:
+# Geokit::Geocoders::google = {
+# 'rubyonrails.org' => 'RUBY_ON_RAILS_API_KEY',
+# ' ruby-docs.org' => 'RUBY_DOCS_API_KEY' }
+
+# This is your username and password for geocoder.us.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, the value should be set to username:password.
+# See http://geocoder.us
+# and http://geocoder.us/user/signup
+# Geokit::Geocoders::UsGeocoder.key = 'username:password'
+
+# This is your authorization key for geocoder.ca.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, set the value to the key obtained from
+# Geocoder.ca.
+# See http://geocoder.ca
+# and http://geocoder.ca/?register=1
+# Geokit::Geocoders::CaGeocoder.key = 'KEY'
+
+# This is your username key for geonames.
+# To use this service either free or premium, you must register a key.
+# See http://www.geonames.org
+# Geokit::Geocoders::GeonamesGeocoder.key = 'KEY'
+
+# Most other geocoders need either no setup or a key
+# Geokit::Geocoders::BingGeocoder.key = ''
+# Geokit::Geocoders::MapQuestGeocoder.key = ''
+# Geokit::Geocoders::YandexGeocoder.key = ''
+# Geokit::Geocoders::MapboxGeocoder.key = 'ACCESS_TOKEN'
+# Geokit::Geocoders::OpencageGeocoder.key = 'some_api_key'
+
+# Geonames has a free service and a premium service, each using a different URL
+# GeonamesGeocoder.premium = true will use http://ws.geonames.net (premium)
+# GeonamesGeocoder.premium = false will use http://api.geonames.org (free)
+# Geokit::Geocoders::GeonamesGeocoder.premium = false
+
+# require "external_geocoder.rb"
+# Please see the section "writing your own geocoders" for more information.
+# Geokit::Geocoders::external_key = 'REPLACE_WITH_YOUR_API_KEY'
+
+# This is the order in which the geocoders are called in a failover scenario
+# If you only want to use a single geocoder, put a single symbol in the array.
+# Valid symbols are :google, :yahoo, :us, and :ca.
+# Be aware that there are Terms of Use restrictions on how you can use the
+# various geocoders.  Make sure you read up on relevant Terms of Use for each
+# geocoder you are going to use.
+# Geokit::Geocoders::provider_order = [:google,:us]
+
+# The IP provider order. Valid symbols are :ip,:geo_plugin.
+# As before, make sure you read up on relevant Terms of Use for each.
+# Geokit::Geocoders::ip_provider_order = [:external,:geo_plugin,:ip]
+
+# Disable HTTPS globally.  This option can also be set on individual
+# geocoder classes.
+# Geokit::Geocoders::secure = false
+
+# Control verification of the server certificate for geocoders using HTTPS
+# Geokit::Geocoders::ssl_verify_mode = OpenSSL::SSL::VERIFY_(PEER/NONE)
+# Setting this to VERIFY_NONE may be needed on systems that don't have
+# a complete or up to date root certificate store. Only applies to
+# the Net::HTTP adapter.

--- a/db/migrate/20191114201641_add_lat_long_to_posts.rb
+++ b/db/migrate/20191114201641_add_lat_long_to_posts.rb
@@ -1,0 +1,10 @@
+class AddLatLongToPosts < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :posts, :location
+
+    add_column :posts, :latitude, :decimal, precision: 10, scale: 6
+    add_column :posts, :longitude, :decimal, precision: 10, scale: 6
+
+    add_index :posts, [:latitude, :longitude]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_01_200930) do
+ActiveRecord::Schema.define(version: 2019_11_14_201641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,11 +28,13 @@ ActiveRecord::Schema.define(version: 2019_11_01_200930) do
   create_table "posts", force: :cascade do |t|
     t.text "body"
     t.integer "likes"
-    t.point "location"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "title"
     t.integer "user_id"
+    t.decimal "latitude", precision: 10, scale: 6
+    t.decimal "longitude", precision: 10, scale: 6
+    t.index ["latitude", "longitude"], name: "index_posts_on_latitude_and_longitude"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -5,11 +5,16 @@
 #  id         :integer          not null, primary key
 #  body       :text
 #  likes      :integer
-#  location   :point
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  title      :string
 #  user_id    :integer
+#  latitude   :decimal(10, 6)
+#  longitude  :decimal(10, 6)
+#
+# Indexes
+#
+#  index_posts_on_latitude_and_longitude  (latitude,longitude)
 #
 
 FactoryBot.define do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -5,11 +5,16 @@
 #  id         :integer          not null, primary key
 #  body       :text
 #  likes      :integer
-#  location   :point
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  title      :string
 #  user_id    :integer
+#  latitude   :decimal(10, 6)
+#  longitude  :decimal(10, 6)
+#
+# Indexes
+#
+#  index_posts_on_latitude_and_longitude  (latitude,longitude)
 #
 
 require 'rails_helper'


### PR DESCRIPTION
## Changes
- Using IP geocoding in geokit-rails, add location to posts
- Add location when creating new posts
- Only render posts within 5 mile radius
    - Note: we're doing posts as points and fixing a 5 mile radius around the user
    - I believe YikYak did it this way as well, and it makes more sense + is easier to code + is faster
    - Also I think the ordering by distance is pretty slow, yay for scalability
- No tests qq

#### Attached issue?
Resolves #33 
Resolves #43 
Resolves #44 