### PR TITLE
Limit post visibility

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,13 +8,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    # TODO: check user loc
     @post = Post.find(params[:id])
-
-    # if @post.publicly_viewable? || @posts.include?(@post)
-    #   puts "does this work"
-    # end
-
     @comments = @post.comments
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -37,6 +37,6 @@ class Post < ApplicationRecord
   end
 
   def within?(latlng)
-    self.distance_to(latlng) < 5.0
+    distance_to(latlng) < 5.0
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -35,4 +35,8 @@ class Post < ApplicationRecord
   def publicly_viewable?
     Post.spiciest.include?(self)
   end
+
+  def within?(latlng)
+    self.distance_to(latlng) < 5.0
+  end
 end

--- a/app/views/posts/_postbody.html.erb
+++ b/app/views/posts/_postbody.html.erb
@@ -1,0 +1,55 @@
+
+<h1><%= @post.title %></h1>
+<% if @post.image.attached? %>
+  <div class="card-image">
+    <%= image_tag @post.image, class: 'img-responsive', alt: 'post image', style: "height: 300px" %>
+  </div>
+<% end %>
+<h4><%= @post.latitude %>, <%= @post.longitude %></h4>
+<p><%= @post.body %></p>
+<h4>spice level: <%= @post.votes_for.size %></h4>
+
+<% if user_signed_in? %>
+  <%= button_to (current_user.liked? @post) ? 'despice' : 'spice',
+      post_toggle_like_post_url(post_id: @post.id),
+      method: :post,
+      params: { post_id: @post.id },
+      class: (current_user.liked? @post) ? 'btn btn-error' : 'btn btn-success' %>
+
+  <div>Write Comment: </div>
+  <%= form_with method: "post", url: post_comments_path(post_id: @post.id), local: true do |form| %>
+    <%= form.hidden_field :user_id, value: current_user.id %>
+    <%= form.hidden_field :post_id, value: @post.id %>
+    <p>
+      <%= form.label :body %><br>
+      <%= form.text_area :body %>
+    </p>
+    <p>
+      <%= form.submit "Post Comment", class: "btn btn-success" %>
+    </p>
+  <% end %>
+<% else %>
+  <p>Login to make a comment!</p>
+<% end %>
+
+<% if @comments.blank? %>
+  <div>No comments...</div>
+<% else %>
+  <div>Comments: </div>
+  <% @comments.each do |comment| %>
+    <div class="card">
+      <div class="card-body">
+        <p><%= comment.body %></p>
+        <% if user_signed_in? %>
+          <%= button_to (current_user.liked? comment) ? "despice: #{comment.votes_for.size}" : "spice: #{comment.votes_for.size}",
+            post_comment_toggle_like_comment_url(post_id: @post.id, comment_id: comment.id),
+            method: :post,
+            params: { comment_id: comment.id },
+            class: (current_user.liked? comment) ? 'btn btn-error' : 'btn btn-success' %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+
+<%= link_to 'Back', '/posts/' %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,14 +10,5 @@
     <% end %>
   </div>
 <% else %>
-  <div class="empty">
-    <div class="empty-icon">
-      <i class="icon icon-location"></i>
-    </div>
-    <p class="empty-title h5">You need to sign in or sign up to view posts.</p>
-    <p class="empty-subtitle">Click the button to make an account.</p>
-    <div class="empty-action">
-      <%= link_to 'Sign up', '/users/sign_up', class: "btn btn-primary" %>
-    </div>
-  </div>
+  <%= render 'shared/notsignedin' %>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,8 +3,7 @@
 <% if false && @post.publicly_viewable? %>
   <%= render partial: 'postbody', locals: { post: @post, comments: @comments } %>
 <% elsif !user_signed_in? %>
-  <%# not entirely sure how to render the real one... %>
-  <%= link_to 'You must log in to see this post!', '/users/sign_in' %>
+  <%= render 'shared/notsignedin' %>
 <% elsif @post.within?(@location) %>
   <%= render partial: 'postbody', locals: { post: @post, comments: @comments } %>
 <% else %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/header' %>
 
-<% if false && @post.publicly_viewable? %>
+<% if @post.publicly_viewable? %>
   <%= render partial: 'postbody', locals: { post: @post, comments: @comments } %>
 <% elsif !user_signed_in? %>
   <%= render 'shared/notsignedin' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,56 +1,14 @@
 <%= render 'shared/header' %>
 
-<h1><%= @post.title %></h1>
-<% if @post.image.attached? %>
-  <div class="card-image">
-    <%= image_tag @post.image, class: 'img-responsive', alt: 'post image', style: "height: 300px" %>
-  </div>
-<% end %>
-<h4><%= @post.latitude %>, <%= @post.longitude %></h4>
-<p><%= @post.body %></p>
-<h4>spice level: <%= @post.votes_for.size %></h4>
-
-<% if user_signed_in? %>
-  <%= button_to (current_user.liked? @post) ? 'despice' : 'spice',
-      post_toggle_like_post_url(post_id: @post.id),
-      method: :post,
-      params: { post_id: @post.id },
-      class: (current_user.liked? @post) ? 'btn btn-error' : 'btn btn-success' %>
-
-  <div>Write Comment: </div>
-  <%= form_with method: "post", url: post_comments_path(post_id: @post.id), local: true do |form| %>
-    <%= form.hidden_field :user_id, value: current_user.id %>
-    <%= form.hidden_field :post_id, value: @post.id %>
-    <p>
-      <%= form.label :body %><br>
-      <%= form.text_area :body %>
-    </p>
-    <p>
-      <%= form.submit "Post Comment", class: "btn btn-success" %>
-    </p>
-  <% end %>
+<% if false && @post.publicly_viewable? %>
+  <%= render partial: 'postbody', locals: { post: @post, comments: @comments } %>
+<% elsif !user_signed_in? %>
+  <%# not entirely sure how to render the real one... %>
+  <%= link_to 'You must log in to see this post!', '/users/sign_in' %>
+<% elsif @post.within?(@location) %>
+  <%= render partial: 'postbody', locals: { post: @post, comments: @comments } %>
 <% else %>
-  <p>Login to make a comment!</p>
+  <%# fetch user loc? %>
+  <%# or maybe we can just be lazy: user will sign in, get redirected to /posts, and obtain location %>
+  <%# instead of redirecting back to the post itself %>
 <% end %>
-
-<% if @comments.blank? %>
-  <div>No comments...</div>
-<% else %>
-  <div>Comments: </div>
-  <% @comments.each do |comment| %>
-    <div class="card">
-      <div class="card-body">
-        <p><%= comment.body %></p>
-        <% if user_signed_in? %>
-          <%= button_to (current_user.liked? comment) ? "despice: #{comment.votes_for.size}" : "spice: #{comment.votes_for.size}",
-            post_comment_toggle_like_comment_url(post_id: @post.id, comment_id: comment.id),
-            method: :post,
-            params: { comment_id: comment.id },
-            class: (current_user.liked? comment) ? 'btn btn-error' : 'btn btn-success' %>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
-<% end %>
-
-<%= link_to 'Back', '/posts/' %>

--- a/app/views/shared/_notsignedin.html.erb
+++ b/app/views/shared/_notsignedin.html.erb
@@ -1,0 +1,10 @@
+  <div class="empty">
+    <div class="empty-icon">
+      <i class="icon icon-location"></i>
+    </div>
+    <p class="empty-title h5">You need to sign in or sign up to view posts.</p>
+    <p class="empty-subtitle">Click the button below to make an account.</p>
+    <div class="empty-action">
+      <%= link_to 'Sign up', '/users/sign_up', class: "btn btn-primary" %>
+    </div>
+  </div>


### PR DESCRIPTION
## Changes
- Only shows publicly viewable posts to non signed in users
- If not public, only shows if signed in and distance is under 5 miles
- If not public and we don't have user location, cheat: make them sign in and redirect to /posts instead of the post itself ;)

#### Attached issue?
Resolves #73 
