### PR TITLE
See distance and time on posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,7 +7,7 @@ class PostsController < ApplicationController
     @sort = params[:sort]
     @posts = case @sort
              when 'spiciest'
-               Post.within_location(@location).order('likes DESC')
+               Post.within_location(@location).order('like_count DESC')
              when 'freshest'
                Post.within_location(@location).order('created_at DESC')
              else

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,9 +1,18 @@
 class ProfilesController < ApplicationController
+  before_action :location
+  
   def profile
     redirect_to '/users/sign_in' unless user_signed_in?
     @user = current_user
     @posts = current_user.posts
     @comments = current_user.comments
     @total_received_spice = @posts.sum { |p| p.likes.count } + @comments.sum { |c| c.likes.count }
+  end
+
+  private
+
+  def location
+    @location = session[:html5_geoloc]
+    @location ||= [0, 0] # TODO: something better
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :location
-  
+
   def profile
     redirect_to '/users/sign_in' unless user_signed_in?
     @user = current_user

--- a/app/views/posts/_postbody.html.erb
+++ b/app/views/posts/_postbody.html.erb
@@ -5,7 +5,9 @@
     <%= image_tag @post.image, class: 'img-responsive', alt: 'post image', style: "height: 300px" %>
   </div>
 <% end %>
-<h4><%= @post.latitude %>, <%= @post.longitude %></h4>
+<% if location.present? %>
+  <h4>Distance: <%= number_with_precision @post.distance_to(location), precision: 2 %>mi</h4>
+<% end %>
 <p><%= @post.body %></p>
 <h4>spice level: <%= @post.likes.count %></h4>
 

--- a/app/views/posts/_postbody.html.erb
+++ b/app/views/posts/_postbody.html.erb
@@ -8,6 +8,7 @@
 <% if location.present? %>
   <h4>Distance: <%= number_with_precision @post.distance_to(location), precision: 2 %>mi</h4>
 <% end %>
+<h4><%= distance_of_time_in_words @post.created_at, Time.now %> ago</h4>
 <p><%= @post.body %></p>
 <h4>spice level: <%= @post.likes.count %></h4>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,7 +10,7 @@
 
   <%= form_tag posts_path, :method => 'get' do %>
     Sort by:
-    <%= select_tag :sort, options_for_select({'Brewing Near You' => 'brewing', 'Spiciest' => 'spiciest', 'Freshest' => 'freshest'}, @sort), :onChange=>'this.form.submit();' %>
+    <%= select_tag :sort, options_for_select({'Closest' => 'closest', 'Spiciest' => 'spiciest', 'Freshest' => 'freshest'}, @sort), :onChange=>'this.form.submit();' %>
   <% end %>
 
   <div id="postcards">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,7 +15,7 @@
 
   <div id="postcards">
     <% @posts.each do |post| %>
-      <%= render partial: 'shared/postcard', locals: { post: post } %>
+      <%= render partial: 'shared/postcard', locals: { post: post, location: @location } %>
     <% end %>
   </div>
 <% else %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,7 +10,7 @@
 
   <%= form_tag posts_path, :method => 'get' do %>
     Sort by:
-    <%= select_tag :sort, options_for_select({'Closest' => 'closest', 'Spiciest' => 'spiciest', 'Freshest' => 'freshest'}, @sort), :onChange=>'this.form.submit();' %>
+    <%= select_tag :sort, options_for_select(['closest', 'spiciest', 'freshest'].index_by(&:capitalize), @sort), :onChange=>'this.form.submit();' %>
   <% end %>
 
   <div id="postcards">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,11 +1,11 @@
 <%= render 'shared/header' %>
 
 <% if @post.publicly_viewable? %>
-  <%= render partial: 'postbody', locals: { post: @post, comments: @comments } %>
+  <%= render partial: 'postbody', locals: { post: @post, comments: @comments, location: nil } %>
 <% elsif !user_signed_in? %>
   <%= render 'shared/notsignedin' %>
 <% elsif @post.user_id == current_user.id || @post.within?(@location) %>
-  <%= render partial: 'postbody', locals: { post: @post, comments: @comments } %>
+  <%= render partial: 'postbody', locals: { post: @post, comments: @comments, location: @location } %>
 <% else %>
   <%# fetch user loc? %>
   <%# or maybe we can just be lazy: user will sign in, get redirected to /posts, and obtain location %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,7 @@
 <%= render 'shared/header' %>
 
 <% if @post.publicly_viewable? %>
-  <%= render partial: 'postbody', locals: { post: @post, comments: @comments, location: nil } %>
+  <%= render partial: 'postbody', locals: { post: @post, comments: @comments, location: @location } %>
 <% elsif !user_signed_in? %>
   <%= render 'shared/notsignedin' %>
 <% elsif @post.user_id == current_user.id || @post.within?(@location) %>

--- a/app/views/profiles/profile.html.erb
+++ b/app/views/profiles/profile.html.erb
@@ -9,7 +9,7 @@
   <div>
     <h2>Your Posts</h2>
     <% @posts.each do |post| %>
-      <%= render partial: 'shared/postcard', locals: { post: post } %>
+      <%= render partial: 'shared/postcard', locals: { post: post, location: @location } %>
     <% end %>
   </div>
   <div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,6 +3,7 @@
     <%= link_to 'TicTacTea', '/', class: "navbar-brand mr-2" %>
     <% if user_signed_in? %>
       <%= link_to 'New Post', '/posts/new', class: "btn btn-link" %>
+      <%= link_to 'Brewing Near You', '/posts', clas: 'btn btn-link' %>
     <% end %>
     <%= link_to 'Spiciest Posts', '/spiciest', class: 'btn btn-link' %>
   </section>

--- a/app/views/shared/_postcard.html.erb
+++ b/app/views/shared/_postcard.html.erb
@@ -17,6 +17,8 @@
   <div class="card-body">
     <span>spice level: <%= post.likes.count %></span>
     <br/>
+    <span><%= distance_of_time_in_words post.created_at, Time.now %> ago</span>
+    <br/>>
     <span><%= post.comments.size %> comment<%= 's' unless post.comments.size == 1 %></span>
   </div>
   <div class="card-footer">

--- a/app/views/shared/_postcard.html.erb
+++ b/app/views/shared/_postcard.html.erb
@@ -1,7 +1,9 @@
 <div class="card">
   <div class="card-header">
     <div class="card-title h5"><%= post.title %></div>
-    <div class="card-subtitle text-gray">location: <%= post.latitude %>, <%= post.longitude %></div>
+    <% if location.present? %>
+      <div class="card-subtitle text-gray">Distance: <%= number_with_precision post.distance_to(location), precision: 2 %>mi</div>
+    <% end %>
   </div>
   <% if post.image.attached? %>
     <div class="card-image">

--- a/app/views/shared/_postcard.html.erb
+++ b/app/views/shared/_postcard.html.erb
@@ -18,7 +18,7 @@
     <span>spice level: <%= post.likes.count %></span>
     <br/>
     <span><%= distance_of_time_in_words post.created_at, Time.now %> ago</span>
-    <br/>>
+    <br/>
     <span><%= post.comments.size %> comment<%= 's' unless post.comments.size == 1 %></span>
   </div>
   <div class="card-footer">

--- a/app/views/spiciest/spiciest.html.erb
+++ b/app/views/spiciest/spiciest.html.erb
@@ -3,5 +3,5 @@
 <h1>Spiciest Posts</h1>
 
 <% @posts.each do |post| %>
-  <%= render partial: 'shared/postcard', locals: { post: post } %>
+  <%= render partial: 'shared/postcard', locals: { post: post, location: nil } %>
 <% end %>


### PR DESCRIPTION
## Changes
- Shows distance instead of lat/long on posts + postcards
- Also shows how old the post is
- Kinda wonky with publicly viewable posts while signed out, it defaults to [0, 0] and shows like 7k miles away
    - Also I might've missed some paths but I think I checked most of it
- Also moves "Brewing Near You" to a header link and renames the sort to just "Closest"

#### Attached issue?
Resolves #49 
Resolves #78 
